### PR TITLE
Use monospace font for fenced code block

### DIFF
--- a/src/extract_slides.js
+++ b/src/extract_slides.js
@@ -266,6 +266,7 @@ inlineTokenRules['paragraph_close'] = function(token, env) {
 
 
 inlineTokenRules['fence'] = function(token, env) {
+    startStyle({fontFamily: 'Courier New, monospace'}, env);
     if(token.info) {
         const htmlTokens = low.highlight(token.info, token.content);
         for(let token of htmlTokens.value) {
@@ -279,6 +280,7 @@ inlineTokenRules['fence'] = function(token, env) {
         env.text.rawText += token.content.replace(/\n/g, '\u000b');
     }
     env.text.rawText += '\n';
+    endStyle(env);
 };
 
 inlineTokenRules['em_open'] = function(token, env) {


### PR DESCRIPTION
Fenced code blocks as of 0.3.0 are not formatted with monospaced typeface. This PR fixed that.

Pardon me as I'm just a backend developer with no background in Javascript, so I can't write test for this PR. I think it's a pretty trivial change, so maybe you could review it without a test case.