### PR TITLE
pass mandatory parameter to `parse` function

### DIFF
--- a/src/extract_slides.js
+++ b/src/extract_slides.js
@@ -77,7 +77,7 @@ function processTokens(tokens, env) {
 }
 
 function parseMarkdown(markdown) {
-    return parser.parse(markdown);
+    return parser.parse(markdown, {});
 }
 
 function processMarkdownToken(token, env) {


### PR DESCRIPTION
- docs: https://markdown-it.github.io/markdown-it/#MarkdownIt.parse
- example of issue without mandatory env parameter:
https://github.com/markdown-it/markdown-it/issues/351